### PR TITLE
Do not check allowed scopes

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -8,7 +8,6 @@
     "taskcluster_client_id": "...",
     "taskcluster_access_token": "...",
     "signing_server_config": "/home/worker/.signing_servers.json",
-    "allowed_signing_scopes": ["signing:cert:dep"],
     "tools_checkout": "/home/worker/tools",
     "my_ip": "127.0.0.1",
     "worker_id": "my_hostname",

--- a/signingworker/consumer.py
+++ b/signingworker/consumer.py
@@ -41,7 +41,6 @@ def main():
             # TODO: use the same format we use for buildbot masters in
             #  passwords.py
             signing_server_config=config.signing_server_config,
-            allowed_signing_scopes=config.allowed_signing_scopes,
             tools_checkout=config.tools_checkout,
             my_ip=config.my_ip,
             worker_id=config.worker_id
@@ -60,7 +59,6 @@ def define_config():
     ns.add_option(name="taskcluster_client_id")
     ns.add_option(name="taskcluster_access_token")
     ns.add_option(name="signing_server_config")
-    ns.add_option(name="allowed_signing_scopes")
     ns.add_option(name="tools_checkout")
     ns.add_option(name="my_ip")
     ns.add_option(name="worker_id")

--- a/signingworker/task.py
+++ b/signingworker/task.py
@@ -7,7 +7,7 @@ from signingworker.exceptions import TaskVerificationError
 log = logging.getLogger(__name__)
 
 
-def validate_task(task, allowed_scopes):
+def validate_task(task):
     # TODO: verify source (signed payload?)
     task_schema = json.load(
         open(
@@ -16,11 +16,6 @@ def validate_task(task, allowed_scopes):
         )
     )
     validate(task, task_schema)
-    if not set(task["scopes"]) & set(allowed_scopes):
-        raise TaskVerificationError(
-            "No allowed scopes ({}) defined in task's scopes ({})".format(
-                allowed_scopes, task["scopes"])
-        )
 
 
 def task_cert_type(task):

--- a/signingworker/test/test_validate_task.py
+++ b/signingworker/test/test_validate_task.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 import json
 import copy
 from signingworker.task import validate_task
-from signingworker.exceptions import TaskVerificationError
 from jsonschema.exceptions import ValidationError
 
 valid_task = json.loads("""
@@ -23,21 +22,13 @@ valid_task = json.loads("""
 }
 """)
 
-allowed_scopes = ["signing"]
 no_scopes = copy.deepcopy(valid_task)
 no_scopes["scopes"] = []
-no_signing_in_scopes = copy.deepcopy(valid_task)
-no_signing_in_scopes["scopes"] = ["no-signing"]
 
 
 class TestValidateTask(TestCase):
     def test_valid_task(self):
-        self.assertIsNone(validate_task(valid_task, allowed_scopes))
+        self.assertIsNone(validate_task(valid_task))
 
     def test_no_scopes(self):
-        self.assertRaises(ValidationError, validate_task, no_scopes,
-                          allowed_scopes)
-
-    def test_no_signing_in_scopes(self):
-        self.assertRaises(TaskVerificationError, validate_task,
-                          no_signing_in_scopes, allowed_scopes)
+        self.assertRaises(ValidationError, validate_task, no_scopes)

--- a/signingworker/worker.py
+++ b/signingworker/worker.py
@@ -28,8 +28,8 @@ log = logging.getLogger(__name__)
 class SigningConsumer(ConsumerMixin):
 
     def __init__(self, connection, exchange, queue_name, worker_type,
-                 taskcluster_config, signing_server_config,
-                 allowed_signing_scopes, tools_checkout, my_ip, worker_id):
+                 taskcluster_config, signing_server_config, tools_checkout,
+                 my_ip, worker_id):
         self.connection = connection
         self.exchange = Exchange(exchange, type='topic', passive=True)
         self.queue_name = queue_name
@@ -38,7 +38,6 @@ class SigningConsumer(ConsumerMixin):
         self.tc_queue = taskcluster.Queue(taskcluster_config)
         self.signing_servers = load_signing_server_config(
             signing_server_config)
-        self.allowed_signing_scopes = allowed_signing_scopes
         self.tools_checkout = tools_checkout
         self.cert = os.path.join(self.tools_checkout,
                                  "release/signing/host.cert")
@@ -66,7 +65,7 @@ class SigningConsumer(ConsumerMixin):
             )
             task = self.tc_queue.task(task_id)
             task_graph_id = task["taskGroupId"]
-            validate_task(task, self.allowed_signing_scopes)
+            validate_task(task)
             self.sign(task_id, run_id, task, work_dir)
             log.debug("Completing: %s, r: %s", task_id, run_id)
             self.tc_queue.reportCompleted(task_id, run_id)


### PR DESCRIPTION
Rely on TC scopes and credentials to determine eligibility of tasks to
use signing infrastructure. Having this logic inside workers complicates
queue operations. Signing workers should support all signing
certificates, as the signing masters do.
